### PR TITLE
Declare Paul Lisker · Projects site name via OG, application-name, and Person/WebSite schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
             "https://www.instagram.com/paullisker/",
             "https://letterboxd.com/plisker/",
             "https://github.com/plisker/",
+            "https://scholar.google.com/citations?user=TRufNXcAAAAJ",
             "https://soundcloud.com/paul-lisker",
             "https://www.last.fm/user/paullisker",
             "https://medium.com/@paullisker"

--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
           "name": "Paul Lisker",
           "url": "https://projects.lisker.me/",
           "jobTitle": "Software Engineer",
+          "alumniOf": {
+            "@type": "CollegeOrUniversity",
+            "name": "Harvard University"
+          },
           "sameAs": [
             "https://www.linkedin.com/in/paullisker/",
             "https://www.instagram.com/paullisker/",

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <link rel="canonical" href="https://projects.lisker.me/" />
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Paul Lisker · Projects" />
     <meta property="og:url" content="https://projects.lisker.me/" />
     <meta property="og:title" content="Paul Lisker | Projects" />
     <meta property="og:description"
@@ -50,6 +51,34 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-config" content="/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
+    <meta name="application-name" content="Paul Lisker · Projects" />
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "Paul Lisker · Projects",
+          "alternateName": "Paul Lisker | Projects",
+          "url": "https://projects.lisker.me/"
+        }
+      </script>
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Paul Lisker",
+          "url": "https://projects.lisker.me/",
+          "jobTitle": "Software Engineer",
+          "sameAs": [
+            "https://www.linkedin.com/in/paullisker/",
+            "https://www.instagram.com/paullisker/",
+            "https://letterboxd.com/plisker/",
+            "https://github.com/plisker/",
+            "https://soundcloud.com/paul-lisker",
+            "https://www.last.fm/user/paullisker",
+            "https://medium.com/@paullisker"
+          ]
+        }
+      </script>
 </head>
 
 <body>


### PR DESCRIPTION
Add explicit site-name signals to projects.lisker.me so Google binds the subdomain to its own identity in search results rather than collapsing it into the lisker.me apex.

Changes, head-only, no visible DOM impact:

- Add `application-name` meta and `og:site_name` — both set to "Paul Lisker · Projects" (middle-dot pattern matches `sub_photos` convention).
- Add WebSite JSON-LD (`name`, `alternateName`, `url`) and Person JSON-LD (`jobTitle`, `sameAs` linking LinkedIn, Instagram, Letterboxd, GitHub, SoundCloud, Last.fm, Medium).
- No changes to `<title>`, `<h1>`, or body markup.

Mirrors the pattern applied in plisker/plisker.github.io#5 and plisker/sub_karyn#2. Validated JSON-LD with `json.loads`; both blocks parse cleanly.

Post-merge verification: https://validator.schema.org/ should list WebSite + Person on https://projects.lisker.me/. Rich Results Test will show nothing — those types aren't rich-result-eligible; this is expected.